### PR TITLE
Add configuration to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ end
 
 The engine should now be mounted at `/mocks` of your project. You can change `"/mocks"` to a different route if you'd prefer it to be elsewhere.
 
+## Configuration
+
+For the mock routes to be accessible you'll also need to enable them.
+
+```ruby
+# config/initializers/defra_ruby_mocks.rb
+require "defra_ruby_mocks"
+
+DefraRubyMocks.configure do |config|
+  config.enable = true
+  config.delay = 1000
+end
+```
+
+To protect against having them enabled when in production, by default the engine will not allow access unless they have been enabled in the config.
+
+We also provide an option to control how long the mock should delay before responding. The default is 1000ms (1 second).
+
 ## Mocks
 
 The project currently mocks the following services.

--- a/app/controllers/defra_ruby_mocks/application_controller.rb
+++ b/app/controllers/defra_ruby_mocks/application_controller.rb
@@ -3,5 +3,15 @@
 module DefraRubyMocks
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
+    before_action :delay_response
+
+    private
+
+    def delay_response
+      # sleep() expects the time to be specified in seconds, but we allow delay
+      # to be specified in milliseconds. Dividing by 1000 converts milliseconds
+      # to seconds.
+      sleep(DefraRubyMocks.configuration.delay / 1000)
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@
 DefraRubyMocks::Engine.routes.draw do
   get "/company/:id",
       to: "company#show",
-      as: "company"
+      as: "company",
+      constraints: ->(_request) { DefraRubyMocks.configuration.enabled }
 end

--- a/lib/defra_ruby_mocks.rb
+++ b/lib/defra_ruby_mocks.rb
@@ -3,4 +3,38 @@
 require "defra_ruby_mocks/engine"
 
 module DefraRubyMocks
+  # Enable the ability to configure the gem from its host app, rather than
+  # reading directly from env vars. Derived from
+  # https://robots.thoughtbot.com/mygem-configure-block
+  class << self
+    attr_writer :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    # Added for testing. Without we cannot test both a config object with and
+    # with set values in the same rspec session
+    def reset_configuration
+      @configuration = nil
+    end
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
+  class Configuration
+    # Set whether the mocks are enabled. Only if set to true will the mock
+    # pages be accessible
+    attr_accessor :enabled
+    # Set a delay in milliseconds for the mocks to respond.
+    # Defaults to 1000 (1 sec)
+    attr_accessor :delay
+
+    def initialize
+      @enabled = false
+      @delay = 1000
+    end
+  end
 end

--- a/spec/defra_ruby_mocks_spec.rb
+++ b/spec/defra_ruby_mocks_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DefraRubyMocks do
   end
 
   describe "#configuration" do
-    before { described_class.reset_configuration }
+    before(:each) { Helpers::Configuration.reset_for_tests }
 
     context "when the host app has not provided configuration" do
       let(:enabled) { false }

--- a/spec/defra_ruby_mocks_spec.rb
+++ b/spec/defra_ruby_mocks_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DefraRubyMocks do
+  describe "VERSION" do
+    it "is a version string in the correct format" do
+      expect(DefraRubyMocks::VERSION).to be_a(String)
+      expect(DefraRubyMocks::VERSION).to match(/\d+\.\d+\.\d+/)
+    end
+  end
+
+  describe "#configuration" do
+    before { described_class.reset_configuration }
+
+    context "when the host app has not provided configuration" do
+      let(:enabled) { false }
+      let(:delay) { 1000 }
+
+      it "returns a DefraRubyMocks::Configuration instance with default values" do
+        expect(described_class.configuration).to be_an_instance_of(DefraRubyMocks::Configuration)
+
+        expect(described_class.configuration.enabled).to eq(enabled)
+        expect(described_class.configuration.delay).to eq(delay)
+      end
+    end
+
+    context "when the host app has provided configuration" do
+      let(:enabled) { true }
+      let(:delay) { 2000 }
+
+      it "returns an DefraRubyMocks::Configuration instance with matching values" do
+        described_class.configure do |config|
+          config.enabled = enabled
+          config.delay = delay
+        end
+
+        expect(described_class.configuration).to be_an_instance_of(DefraRubyMocks::Configuration)
+        expect(described_class.configuration.enabled).to eq(enabled)
+        expect(described_class.configuration.delay).to eq(delay)
+      end
+    end
+  end
+end

--- a/spec/requests/company_spec.rb
+++ b/spec/requests/company_spec.rb
@@ -4,6 +4,13 @@ require "rails_helper"
 
 module DefraRuby
   RSpec.describe "Company", type: :request do
+    before(:all) do
+      DefraRubyMocks.configure do |config|
+        config.delay = 100
+      end
+    end
+    after(:all) { DefraRubyMocks.reset_configuration }
+
     let(:path) { "/defra_ruby_mocks/company" }
 
     context "when the company number is from the 'specials' list" do

--- a/spec/requests/company_spec.rb
+++ b/spec/requests/company_spec.rb
@@ -4,12 +4,8 @@ require "rails_helper"
 
 module DefraRuby
   RSpec.describe "Company", type: :request do
-    before(:all) do
-      DefraRubyMocks.configure do |config|
-        config.delay = 100
-      end
-    end
-    after(:all) { DefraRubyMocks.reset_configuration }
+    before(:all) { Helpers::Configuration.prep_for_tests }
+    after(:all) { Helpers::Configuration.reset_for_tests }
 
     let(:path) { "/defra_ruby_mocks/company" }
 

--- a/spec/support/helpers/configuration.rb
+++ b/spec/support/helpers/configuration.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Helpers
+  module Configuration
+    def self.prep_for_tests(delay = 100)
+      DefraRubyMocks.configure do |config|
+        config.enabled = true
+        config.delay = delay
+      end
+    end
+
+    def self.reset_for_tests
+      DefraRubyMocks.reset_configuration
+    end
+  end
+end


### PR DESCRIPTION
When we implemented mocks before, we have also provided a way to both enable the mocks (or disable them) but also implement a delay in the response.

By default we don't want the mocks enabled to protect against them accidently being used in production. And because we are not crunching through some massive database or carrying out any complex logic, our mock responses are likely to be far quicker than the real ones. So we also provide a means of introducing a configurable delay in the mock response.