### PR TITLE
Fix 'config.enabled'. Should be 'enable'

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ DefraRubyMocks::Engine.routes.draw do
   get "/company/:id",
       to: "company#show",
       as: "company",
-      constraints: ->(_request) { DefraRubyMocks.configuration.enabled }
+      constraints: ->(_request) { DefraRubyMocks.configuration.enable }
 end

--- a/lib/defra_ruby_mocks/configuration.rb
+++ b/lib/defra_ruby_mocks/configuration.rb
@@ -4,22 +4,22 @@ module DefraRubyMocks
   class Configuration
     # Controls whether the mocks are enabled. Only if set to true will the mock
     # pages be accessible
-    attr_reader :enabled
+    attr_reader :enable
     # Set a delay in milliseconds for the mocks to respond.
     # Defaults to 1000 (1 sec)
     attr_accessor :delay
 
     def initialize
-      @enabled = false
+      @enable = false
       @delay = 1000
     end
 
     # We implement our own setter to handle values being passed in as strings
     # rather than booleans
-    def enabled=(arg)
+    def enable=(arg)
       parsed = arg.to_s.downcase
 
-      @enabled = parsed == "true"
+      @enable = parsed == "true"
     end
   end
 end

--- a/spec/defra_ruby_mocks_spec.rb
+++ b/spec/defra_ruby_mocks_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DefraRubyMocks do
       it "returns a DefraRubyMocks::Configuration instance with default values" do
         expect(described_class.configuration).to be_an_instance_of(DefraRubyMocks::Configuration)
 
-        expect(described_class.configuration.enabled).to eq(enabled)
+        expect(described_class.configuration.enable).to eq(enabled)
         expect(described_class.configuration.delay).to eq(delay)
       end
     end
@@ -31,12 +31,12 @@ RSpec.describe DefraRubyMocks do
 
       it "returns an DefraRubyMocks::Configuration instance with matching values" do
         described_class.configure do |config|
-          config.enabled = enabled
+          config.enable = enabled
           config.delay = delay
         end
 
         expect(described_class.configuration).to be_an_instance_of(DefraRubyMocks::Configuration)
-        expect(described_class.configuration.enabled).to eq(enabled)
+        expect(described_class.configuration.enable).to eq(enabled)
         expect(described_class.configuration.delay).to eq(delay)
       end
     end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -4,36 +4,36 @@ module DefraRubyMocks
   RSpec.describe Configuration do
     let(:subject) { described_class.new }
 
-    describe "#enabled=" do
+    describe "#enable=" do
       context "when passed true as boolean" do
-        it "sets enabled to 'true'" do
-          subject.enabled = true
+        it "sets enable to 'true'" do
+          subject.enable = true
 
-          expect(subject.enabled).to be(true)
+          expect(subject.enable).to be(true)
         end
       end
 
       context "when passed false as a boolean" do
-        it "sets enabled to 'false'" do
-          subject.enabled = false
+        it "sets enable to 'false'" do
+          subject.enable = false
 
-          expect(subject.enabled).to be(false)
+          expect(subject.enable).to be(false)
         end
       end
 
       context "when passed true as string" do
-        it "sets enabled to 'true'" do
-          subject.enabled = "true"
+        it "sets enable to 'true'" do
+          subject.enable = "true"
 
-          expect(subject.enabled).to be(true)
+          expect(subject.enable).to be(true)
         end
       end
 
       context "when passed false as a string" do
-        it "sets enabled to 'false'" do
-          subject.enabled = "false"
+        it "sets enable to 'false'" do
+          subject.enable = "false"
 
-          expect(subject.enabled).to be(false)
+          expect(subject.enable).to be(false)
         end
       end
     end

--- a/spec/requests/company_spec.rb
+++ b/spec/requests/company_spec.rb
@@ -67,7 +67,7 @@ module DefraRuby
     end
 
     context "when mocks are disabled" do
-      before(:all) { DefraRubyMocks.configuration.enabled = false }
+      before(:all) { DefraRubyMocks.configuration.enable = false }
 
       let(:company_number) { "SC247974" }
 

--- a/spec/support/helpers/configuration.rb
+++ b/spec/support/helpers/configuration.rb
@@ -4,7 +4,7 @@ module Helpers
   module Configuration
     def self.prep_for_tests(delay = 100)
       DefraRubyMocks.configure do |config|
-        config.enabled = true
+        config.enable = true
         config.delay = delay
       end
     end


### PR DESCRIPTION
When double checking the documentation for where we are at, we spotted that it referred to the field as `enable` whereas the code had it as `enabled`.

On review `enabled` would be better suited to a method called `enabled?` so we opted for the name used in the documentation and updated the code accordingly.