### PR TITLE
Better name enable attr_reader on Configuration

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ DefraRubyMocks::Engine.routes.draw do
   get "/company/:id",
       to: "company#show",
       as: "company",
-      constraints: ->(_request) { DefraRubyMocks.configuration.enable }
+      constraints: ->(_request) { DefraRubyMocks.configuration.enabled? }
 end

--- a/lib/defra_ruby_mocks/configuration.rb
+++ b/lib/defra_ruby_mocks/configuration.rb
@@ -2,9 +2,6 @@
 
 module DefraRubyMocks
   class Configuration
-    # Controls whether the mocks are enabled. Only if set to true will the mock
-    # pages be accessible
-    attr_reader :enable
     # Set a delay in milliseconds for the mocks to respond.
     # Defaults to 1000 (1 sec)
     attr_accessor :delay
@@ -14,12 +11,18 @@ module DefraRubyMocks
       @delay = 1000
     end
 
-    # We implement our own setter to handle values being passed in as strings
-    # rather than booleans
+    # Controls whether the mocks are enabled. Only if set to true will the mock
+    # pages be accessible
     def enable=(arg)
+      # We implement our own setter to handle values being passed in as strings
+      # rather than booleans
       parsed = arg.to_s.downcase
 
       @enable = parsed == "true"
+    end
+
+    def enabled?
+      @enable
     end
   end
 end

--- a/spec/defra_ruby_mocks_spec.rb
+++ b/spec/defra_ruby_mocks_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DefraRubyMocks do
       it "returns a DefraRubyMocks::Configuration instance with default values" do
         expect(described_class.configuration).to be_an_instance_of(DefraRubyMocks::Configuration)
 
-        expect(described_class.configuration.enable).to eq(enabled)
+        expect(described_class.configuration.enabled?).to eq(enabled)
         expect(described_class.configuration.delay).to eq(delay)
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe DefraRubyMocks do
         end
 
         expect(described_class.configuration).to be_an_instance_of(DefraRubyMocks::Configuration)
-        expect(described_class.configuration.enable).to eq(enabled)
+        expect(described_class.configuration.enabled?).to eq(enabled)
         expect(described_class.configuration.delay).to eq(delay)
       end
     end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -9,7 +9,7 @@ module DefraRubyMocks
         it "sets enable to 'true'" do
           subject.enable = true
 
-          expect(subject.enable).to be(true)
+          expect(subject.enabled?).to be(true)
         end
       end
 
@@ -17,7 +17,7 @@ module DefraRubyMocks
         it "sets enable to 'false'" do
           subject.enable = false
 
-          expect(subject.enable).to be(false)
+          expect(subject.enabled?).to be(false)
         end
       end
 
@@ -25,7 +25,7 @@ module DefraRubyMocks
         it "sets enable to 'true'" do
           subject.enable = "true"
 
-          expect(subject.enable).to be(true)
+          expect(subject.enabled?).to be(true)
         end
       end
 
@@ -33,7 +33,7 @@ module DefraRubyMocks
         it "sets enable to 'false'" do
           subject.enable = "false"
 
-          expect(subject.enable).to be(false)
+          expect(subject.enabled?).to be(false)
         end
       end
     end


### PR DESCRIPTION
Reading from an attribute named `enable` on the `Configuration` class didn't feel right or read correctly in the code.

So this change replaces the `attr_reader` with our own method called `enabled?` which we believe is a better fit and makes more sense when used in the code.