### PR TITLE
Fix Configuration.delay to handle strings

### DIFF
--- a/lib/defra_ruby_mocks/configuration.rb
+++ b/lib/defra_ruby_mocks/configuration.rb
@@ -2,13 +2,14 @@
 
 module DefraRubyMocks
   class Configuration
-    # Set a delay in milliseconds for the mocks to respond.
-    # Defaults to 1000 (1 sec)
-    attr_accessor :delay
+
+    DEFAULT_DELAY = 1000
+
+    attr_reader :delay
 
     def initialize
       @enable = false
-      @delay = 1000
+      @delay = DEFAULT_DELAY
     end
 
     # Controls whether the mocks are enabled. Only if set to true will the mock
@@ -23,6 +24,16 @@ module DefraRubyMocks
 
     def enabled?
       @enable
+    end
+
+    # Set a delay in milliseconds for the mocks to respond.
+    # Defaults to 1000 (1 sec)
+    def delay=(arg)
+      # We implement our own setter to handle values being passed in as strings
+      # rather than integers
+      @delay = arg.to_i
+
+      @delay = DEFAULT_DELAY if @delay.zero?
     end
   end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -37,5 +37,39 @@ module DefraRubyMocks
         end
       end
     end
+
+    describe "#delay=" do
+      context "when passed 200 as an integer" do
+        it "sets delay to 200" do
+          subject.delay = 200
+
+          expect(subject.delay).to be(200)
+        end
+      end
+
+      context "when passed 200 as a string" do
+        it "sets delay to 200" do
+          subject.delay = "200"
+
+          expect(subject.delay).to be(200)
+        end
+      end
+
+      context "when passed a string that's not a number" do
+        it "sets delay to its default" do
+          subject.delay = ""
+
+          expect(subject.delay).to be(Configuration::DEFAULT_DELAY)
+        end
+      end
+
+      context "when passed nil" do
+        it "sets delay to its default" do
+          subject.delay = nil
+
+          expect(subject.delay).to be(Configuration::DEFAULT_DELAY)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
A bit like changes we made to `enable` to handle values being passed in as strings rather than integers, we should have spotted that the same will apply to `delay`.

Again we can expect the same usage patterns for setting the config

```ruby
DefraRubyMocks::configure do |config|
  config.enable = ENV["ENABLE_MOCKS"] || false
  config.enable = ENV["MOCK_DELAY"] || 1000
end
```

So there is a good chance the value of the env var will just be chucked straight across rather than the host app converting it first to an integer.