### PR TITLE
Add ability for Worldpay to reject payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ This Worldpay mock replicates those 2 interactions with the following urls
 - `../worldpay/payments-service`
 - `../worldpay/dispatcher`
 
+##### Refused payments
+
+The engine has the ability to also mock Worldpay refusing a payment. To have the mock refuse payment just ensure the registration's company name includes the word `reject` (case doesn't matter).
+
+If it does the engine will redirect back to the failure url instead of the success url provided, plus set the payment status to `REFUSED`.
+
+This allows us to test how the application handles both successful and unsucessful Worldpay payments.
+
 #### Refunds
 
 Requesting a refund from Worldpay is a single step process.

--- a/app/controllers/defra_ruby_mocks/worldpay_controller.rb
+++ b/app/controllers/defra_ruby_mocks/worldpay_controller.rb
@@ -15,8 +15,10 @@ module DefraRubyMocks
     end
 
     def dispatcher
-      success_url = params[:successURL]
-      redirect_to WorldpayResponseService.run(success_url)
+      redirect_to WorldpayResponseService.run(
+        success_url: params[:successURL],
+        failure_url: params[:failureURL]
+      )
     rescue StandardError
       head 500
     end

--- a/spec/requests/worldpay_spec.rb
+++ b/spec/requests/worldpay_spec.rb
@@ -60,7 +60,7 @@ module DefraRubyMocks
 
       context "#dispatcher" do
         let(:relation) { double(:relation, first: registration) }
-        let(:registration) { double(:registration, finance_details: finance_details) }
+        let(:registration) { double(:registration, finance_details: finance_details, company_name: "What a waste") }
         let(:finance_details) { double(:finance_details, orders: orders) }
         let(:orders) { double(:orders, order_by: sorted_orders) }
         let(:sorted_orders) { double(:sorted_orders, first: order) }

--- a/spec/services/worldpay_response_service_spec.rb
+++ b/spec/services/worldpay_response_service_spec.rb
@@ -23,8 +23,9 @@ module DefraRubyMocks
     let(:order_code) { "54321" }
     let(:order_key) { "#{admin_code}^#{merchant_code}^#{order_code}" }
     let(:order_value) { 105_00 }
+    let(:company_name) { "Pay for the thing" }
 
-    let(:registration) { double(:registration, finance_details: finance_details) }
+    let(:registration) { double(:registration, finance_details: finance_details, company_name: company_name) }
     let(:finance_details) { double(:finance_details, orders: orders) }
     let(:orders) { double(:orders, order_by: sorted_orders) }
     let(:sorted_orders) { double(:sorted_orders, first: order) }
@@ -42,10 +43,12 @@ module DefraRubyMocks
       Digest::MD5.hexdigest(data.join).to_s
     end
 
+    let(:payment_status) { "AUTHORISED" }
+
     let(:query_string) do
       [
         "orderKey=#{order_key}",
-        "paymentStatus=AUTHORISED",
+        "paymentStatus=#{payment_status}",
         "paymentAmount=#{order_value}",
         "paymentCurrency=GBP",
         "mac=#{mac}",
@@ -53,35 +56,51 @@ module DefraRubyMocks
       ].join("&")
     end
 
+    let(:args) { { success_url: success_url, failure_url: failure_url } }
+
     describe ".run" do
       context "when the request comes from the waste-carriers-front-office" do
         let(:success_url) { "http://example.com/fo/#{reference}/worldpay/success" }
+        let(:failure_url) { "http://example.com/fo/#{reference}/worldpay/failure" }
 
         context "and is valid" do
           let(:relation) { double(:relation, first: registration) }
 
           it "can extract the reference from the `success_url`" do
-            described_class.run(success_url)
+            described_class.run(args)
 
             expect(::WasteCarriersEngine::TransientRegistration).to have_received(:where).with(token: reference)
           end
 
           it "can generate a valid order key" do
-            params = parse_for_params(described_class.run(success_url))
+            params = parse_for_params(described_class.run(args))
 
             expect(params["orderKey"]).to eq(order_key)
           end
 
           it "can generate a valid mac" do
-            params = parse_for_params(described_class.run(success_url))
+            params = parse_for_params(described_class.run(args))
 
             expect(params["mac"]).to eq(mac)
           end
 
-          it "returns a url in the expected format" do
-            expected_response = "#{success_url}?#{query_string}"
+          context "and is for a successful payment" do
+            it "returns a url in the expected format" do
+              expected_response = "#{success_url}?#{query_string}"
 
-            expect(described_class.run(success_url)).to eq(expected_response)
+              expect(described_class.run(args)).to eq(expected_response)
+            end
+          end
+
+          context "and is for a rejected payment" do
+            let(:payment_status) { "REFUSED" }
+            let(:company_name) { "Reject for the thing" }
+
+            it "returns a url in the expected format" do
+              expected_response = "#{failure_url}?#{query_string}"
+
+              expect(described_class.run(args)).to eq(expected_response)
+            end
           end
         end
 
@@ -89,7 +108,15 @@ module DefraRubyMocks
           let(:relation) { double(:relation, first: nil) }
 
           it "causes an error" do
-            expect { described_class.run(success_url) }.to raise_error MissingRegistrationError
+            expect { described_class.run(args) }.to raise_error MissingRegistrationError
+          end
+        end
+
+        context "but the registration does not exist" do
+          let(:relation) { double(:relation, first: nil) }
+
+          it "causes an error" do
+            expect { described_class.run(args) }.to raise_error MissingRegistrationError
           end
         end
       end
@@ -104,32 +131,46 @@ module DefraRubyMocks
         end
 
         let(:success_url) { "http://example.com/your-registration/#{reference}/worldpay/success/54321/NEWREG?locale=en" }
+        let(:failure_url) { "http://example.com/your-registration/#{reference}/worldpay/failure/54321/NEWREG?locale=en" }
 
         context "and is valid" do
           let(:relation) { double(:relation, first: registration) }
 
           it "can extract the reference from the `success_url`" do
-            described_class.run(success_url)
+            described_class.run(args)
 
             expect(::WasteCarriersEngine::Registration).to have_received(:where).with(reg_uuid: reference)
           end
 
           it "can generate a valid order key" do
-            params = parse_for_params(described_class.run(success_url))
+            params = parse_for_params(described_class.run(args))
 
             expect(params["orderKey"]).to eq(order_key)
           end
 
           it "can generate a valid mac" do
-            params = parse_for_params(described_class.run(success_url))
+            params = parse_for_params(described_class.run(args))
 
             expect(params["mac"]).to eq(mac)
           end
 
-          it "returns a url in the expected format" do
-            expected_response = "#{success_url}&#{query_string}"
+          context "and is for a successful payment" do
+            it "returns a url in the expected format" do
+              expected_response = "#{success_url}&#{query_string}"
 
-            expect(described_class.run(success_url)).to eq(expected_response)
+              expect(described_class.run(args)).to eq(expected_response)
+            end
+          end
+
+          context "and is for a rejected payment" do
+            let(:payment_status) { "REFUSED" }
+            let(:company_name) { "Reject for the thing" }
+
+            it "returns a url in the expected format" do
+              expected_response = "#{failure_url}&#{query_string}"
+
+              expect(described_class.run(args)).to eq(expected_response)
+            end
           end
         end
 
@@ -137,7 +178,7 @@ module DefraRubyMocks
           let(:relation) { double(:relation, first: nil) }
 
           it "causes an error" do
-            expect { described_class.run(success_url) }.to raise_error MissingRegistrationError
+            expect { described_class.run(args) }.to raise_error MissingRegistrationError
           end
         end
       end


### PR DESCRIPTION
It was highlighted by the team's QA that some of our automated acceptance tests replicate Worldpay rejecting a payment in order to see how the system handles it.

Currently the mocks can't do this, so we were asked what could be done instead.

Our response was to say they can (will!) do this.