### PR TITLE
Fix rubocop cop rename issue

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ Bundler::GemHelper.install_tasks
 # This is wrapped to prevent an error when rake is called in environments where
 # rspec may not be available, e.g. production. As such we don't need to handle
 # the error.
-# rubocop:disable Lint/HandleExceptions
+# rubocop:disable Lint/SuppressedException
 begin
   require "rspec/core/rake_task"
 
@@ -35,4 +35,4 @@ begin
 rescue LoadError
   # no rspec available
 end
-# rubocop:enable Lint/HandleExceptions
+# rubocop:enable Lint/SuppressedException


### PR DESCRIPTION
We spotted that automated builds on master by Travis-CI had started failing.

The issue is that rubocop has released a new version (0.77) and it looks like it has changed the name of the cop which checks suppressed exceptions.