### PR TITLE
Add support for copy card orders in WCR

### DIFF
--- a/app/services/defra_ruby_mocks/worldpay_response_service.rb
+++ b/app/services/defra_ruby_mocks/worldpay_response_service.rb
@@ -60,11 +60,12 @@ module DefraRubyMocks
     end
 
     def reject_payment?
-      company_name = if @resource.is_a?(WasteCarriersEngine::OrderCopyCardsRegistration)
+      company_name = if @resource.class.to_s == "WasteCarriersEngine::OrderCopyCardsRegistration"
                        locate_original_registration(@resource.reg_identifier).company_name
                      else
                        @resource.company_name
                      end
+
       company_name.downcase.include?("reject")
     end
 

--- a/app/services/defra_ruby_mocks/worldpay_response_service.rb
+++ b/app/services/defra_ruby_mocks/worldpay_response_service.rb
@@ -5,7 +5,7 @@ module DefraRubyMocks
 
     def run(success_url:, failure_url:)
       parse_reference(success_url)
-      locate_registration
+      locate_resource
       @order = last_order
 
       response_url(success_url, failure_url)
@@ -28,10 +28,10 @@ module DefraRubyMocks
       end
     end
 
-    def locate_registration
-      @registration = locate_transient_registration || locate_completed_registration
+    def locate_resource
+      @resource = locate_transient_registration || locate_completed_registration
 
-      raise(MissingRegistrationError, @reference) if @registration.nil?
+      raise(MissingRegistrationError, @reference) if @resource.nil?
     end
 
     def locate_transient_registration
@@ -56,14 +56,14 @@ module DefraRubyMocks
     end
 
     def last_order
-      @registration.finance_details&.orders&.order_by(dateCreated: :desc)&.first
+      @resource.finance_details&.orders&.order_by(dateCreated: :desc)&.first
     end
 
     def reject_payment?
-      company_name = if @registration.is_a?(WasteCarriersEngine::OrderCopyCardsRegistration)
-                       locate_original_registration(@registration.reg_identifier).company_name
+      company_name = if @resource.is_a?(WasteCarriersEngine::OrderCopyCardsRegistration)
+                       locate_original_registration(@resource.reg_identifier).company_name
                      else
-                       @registration.company_name
+                       @resource.company_name
                      end
       company_name.downcase.include?("reject")
     end

--- a/app/services/defra_ruby_mocks/worldpay_response_service.rb
+++ b/app/services/defra_ruby_mocks/worldpay_response_service.rb
@@ -41,6 +41,13 @@ module DefraRubyMocks
         .first
     end
 
+    def locate_original_registration(reg_identifier)
+      "WasteCarriersEngine::Registration"
+        .constantize
+        .where(reg_identifier: reg_identifier)
+        .first
+    end
+
     def locate_completed_registration
       "WasteCarriersEngine::Registration"
         .constantize
@@ -53,7 +60,12 @@ module DefraRubyMocks
     end
 
     def reject_payment?
-      @registration.company_name.downcase.include?("reject")
+      company_name = if @registration.is_a?(WasteCarriersEngine::OrderCopyCardsRegistration)
+                       locate_original_registration(@registration.reg_identifier).company_name
+                     else
+                       @registration.company_name
+                     end
+      company_name.downcase.include?("reject")
     end
 
     def order_key


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1044

The old [waste-carriers-frontend](https://github.com/DEFRA/waste-carriers-frontend) had a copy cards feature that simply piggy backed on the registration and used the same process as used when paying for a new registration.

Our Worldpay mock handles this, plus dealing with renewals via transient registrations collection in the database. That version of ordering copy cards is now defunt and has been replaced by a new version in the [https://github.com/DEFRA/waste-carriers-back-office).

It creates a separate transient registration of type `WasteCarriersEngine::OrderCopyCardsRegistration` which only includes a few details from the original registration. Unfortunately `company_name` is not one of them.

Our `WorldpayResponseService` uses the company name to determine if we should mock Worldpay `REFUSE`ing the payment. We look in the company name for the term `reject` and if found `REFUSE` the payment.

We could have amended the code so that if what we are dealing with is a `OrderCopyCardsRegistration` we always return a successful response. But instead we decided to keep the option to simulate Worldpay refusing a copy card order payment. In this way our QA has the scope and flexibilty to test what happens in these scenarios.

So this change updates the `WorldpayResponseService` to handle tracking down the company name for copy card orders so they can still be refused and possibly other result types in the future.