### PR TITLE
Fix generated MAC for refused payments

### DIFF
--- a/app/services/defra_ruby_mocks/worldpay_response_service.rb
+++ b/app/services/defra_ruby_mocks/worldpay_response_service.rb
@@ -68,12 +68,12 @@ module DefraRubyMocks
       @order.total_amount.to_s
     end
 
-    def generate_mac
+    def generate_mac(status)
       data = [
         order_key,
         order_value,
         "GBP",
-        "AUTHORISED",
+        status,
         DefraRubyMocks.configuration.worldpay_mac_secret
       ]
 
@@ -86,7 +86,7 @@ module DefraRubyMocks
         "paymentStatus=#{status}",
         "paymentAmount=#{order_value}",
         "paymentCurrency=GBP",
-        "mac=#{generate_mac}",
+        "mac=#{generate_mac(status)}",
         "source=WP"
       ].join("&")
     end

--- a/spec/services/worldpay_response_service_spec.rb
+++ b/spec/services/worldpay_response_service_spec.rb
@@ -23,6 +23,7 @@ module DefraRubyMocks
     let(:order_code) { "54321" }
     let(:order_key) { "#{admin_code}^#{merchant_code}^#{order_code}" }
     let(:order_value) { 105_00 }
+    let(:payment_status) { "AUTHORISED" }
     let(:company_name) { "Pay for the thing" }
 
     let(:registration) { double(:registration, finance_details: finance_details, company_name: company_name) }
@@ -36,14 +37,12 @@ module DefraRubyMocks
         order_key,
         order_value,
         "GBP",
-        "AUTHORISED",
+        payment_status,
         mac_secret
       ]
 
       Digest::MD5.hexdigest(data.join).to_s
     end
-
-    let(:payment_status) { "AUTHORISED" }
 
     let(:query_string) do
       [


### PR DESCRIPTION
Spotted whilst working on a new enhancement (PR #32) that if are asked to return a `REFUSED` payment response that we are not actually generating the MAC correctly.

The MAC needs to include the status when generated but we had it hard coded to always be `AUTHORISED`. This means if the registration in question has the term 'reject' in its company name, which means we are being asked to mock a `REFUSED` response, the MAC we generate won't match what the app expects because it will be expecting one where the status is `REFUSED`.

We do already work out the status correctly. We're just not getting it to the method where we generate the MAC.

This change fixes that.