### PR TITLE
Fix issue with intermittent auth issues

### DIFF
--- a/app/controllers/defra_ruby_mocks/company_controller.rb
+++ b/app/controllers/defra_ruby_mocks/company_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DefraRubyMocks
-  class CompanyController < ApplicationController
+  class CompanyController < ::DefraRubyMocks::ApplicationController
 
     before_action :set_default_response_format
 

--- a/app/controllers/defra_ruby_mocks/worldpay_controller.rb
+++ b/app/controllers/defra_ruby_mocks/worldpay_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DefraRubyMocks
-  class WorldpayController < ApplicationController
+  class WorldpayController < ::DefraRubyMocks::ApplicationController
 
     before_action :set_default_response_format
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1040

We have an intermittent issue with the mocks where requests to Worldpay or Companies House (the mocked versions!) will start failing. Some of us have never experienced it, others once or twice. But for our QA @andrewhick who is constantly running acceptance tests against the Vagrant environment, this is happens multiple times a day.

After some great detective work by @cintamani we think its because

> [..] in some cases the https://github.com/DEFRA/defra-ruby-mocks/blob/master/app/controllers/defra_ruby_mocks/company_controller.rb#L4 is inheriting from the application controller defined in the [app] rather than the scoped one.

When we checked the logs of Andrew's machine the reason the requests were failing was a 403 unauthorized response. This explains our suspicion about Rails getting confused about the inherited controller. We experienced a similar issue in our work to upgrade our services to Rails 6 and Ruby 2.7. The fix we believe is to be more explicit about which application controller we are inheriting from in the engine's controllers.