### PR TITLE
Add mocking of pending Worldpay payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ If it does the engine will redirect back to the failure url instead of the succe
 
 This allows us to test how the application handles both successful and unsucessful Worldpay payments.
 
+##### Pending payments
+
+The engine has the ability to also mock Worldpay marking a payment as pending. To have the mock return a payment pending response just ensure the registration's company name includes the word `pending` (case doesn't matter).
+
+If it does the engine will redirect back to the pending url instead of the success url provided, plus set the payment status to `SENT_FOR_AUTHORISATION`.
+
+This allows us to test how the application handles Worldpay responding with a payment pending response.
+
 ##### Stuck payments
 
 The engine has the ability to also mock Worldpay not redirecting back to the service. This is the equivalent of a registration getting 'stuck at Worldpay'. To have the mock not respond just ensure the registration's company name includes the word `stuck` (case doesn't matter).

--- a/app/controllers/defra_ruby_mocks/worldpay_controller.rb
+++ b/app/controllers/defra_ruby_mocks/worldpay_controller.rb
@@ -17,7 +17,8 @@ module DefraRubyMocks
     def dispatcher
       @response = WorldpayResponseService.run(
         success_url: params[:successURL],
-        failure_url: params[:failureURL]
+        failure_url: params[:failureURL],
+        pending_url: params[:pendingURL]
       )
 
       if @response.status == :STUCK

--- a/spec/requests/worldpay_spec.rb
+++ b/spec/requests/worldpay_spec.rb
@@ -59,8 +59,18 @@ module DefraRubyMocks
       end
 
       context "#dispatcher" do
+        let(:success_url) { "http://example.com/fo/12345/worldpay/success" }
+        let(:failure_url) { "http://example.com/fo/12345/worldpay/failure" }
+        let(:pending_url) { "http://example.com/fo/12345/worldpay/pending" }
         let(:response_url) { "#{success_url}?orderKey=admincode1^^987654&paymentStatus=#{status}&paymentAmount=10500&paymentCurrency=GBP&mac=0ba5271e1ed1b26f9bb428ef7fb536a4&source=WP" }
-        let(:path) { "/defra_ruby_mocks/worldpay/dispatcher?successURL=#{CGI.escape(success_url)}" }
+        let(:path) do
+          root = "/defra_ruby_mocks/worldpay/dispatcher"
+          escaped_success = CGI.escape(success_url)
+          escaped_failure = CGI.escape(failure_url)
+          escaped_pending = CGI.escape(pending_url)
+
+          "#{root}?successURL=#{escaped_success}&failureURL=#{escaped_failure}&pendingURL=#{escaped_pending}"
+        end
         let(:service_response) do
           double(
             :response,
@@ -76,9 +86,14 @@ module DefraRubyMocks
         end
 
         context "and the request is valid" do
-          before(:each) { allow(WorldpayResponseService).to receive(:run) { service_response } }
-
-          let(:success_url) { "http://example.com/fo/12345/worldpay/success" }
+          before(:each) do
+            allow(WorldpayResponseService).to receive(:run)
+              .with(
+                success_url: success_url,
+                failure_url: failure_url,
+                pending_url: pending_url
+              ) { service_response }
+          end
 
           context "and a response is expected" do
             let(:status) { "AUTHORISED" }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1045

This change adds the ability to 'mock' a pening Worldpay payment to the engine.

There are times when the Worldpay payment completes and it returns a `PENDING` response but this does not actually mean payment has been taken. We believe this happens when further checks need to be made before transfer of funds can be authorised by the bank.

We cater for this in both the renewal and new egistration journeys so our QA @andrewhick would also like to provide coverage via our acceptance tests.