### PR TITLE
Add mocking of cancelled Worldpay payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ This Worldpay mock replicates those 2 interactions with the following urls
 - `../worldpay/payments-service`
 - `../worldpay/dispatcher`
 
+##### Cancelled payments
+
+The engine has the ability to mock a user cancelling a payment when on the Worldpay site. To have the mock return a cancelled payment response just ensure the registration's company name includes the word `cancel` (case doesn't matter).
+
+If it does the engine will redirect back to the pending url instead of the success url provided, plus set the payment status to `CANCELLED`.
+
+This allows us to test how the application handles Worldpay responding with a cancelled payment response.
+
 ##### Refused payments
 
 The engine has the ability to also mock Worldpay refusing a payment. To have the mock refuse payment just ensure the registration's company name includes the word `reject` (case doesn't matter).

--- a/app/controllers/defra_ruby_mocks/worldpay_controller.rb
+++ b/app/controllers/defra_ruby_mocks/worldpay_controller.rb
@@ -18,7 +18,8 @@ module DefraRubyMocks
       @response = WorldpayResponseService.run(
         success_url: params[:successURL],
         failure_url: params[:failureURL],
-        pending_url: params[:pendingURL]
+        pending_url: params[:pendingURL],
+        cancel_url: params[:cancelURL]
       )
 
       if @response.status == :STUCK

--- a/spec/requests/worldpay_spec.rb
+++ b/spec/requests/worldpay_spec.rb
@@ -62,14 +62,16 @@ module DefraRubyMocks
         let(:success_url) { "http://example.com/fo/12345/worldpay/success" }
         let(:failure_url) { "http://example.com/fo/12345/worldpay/failure" }
         let(:pending_url) { "http://example.com/fo/12345/worldpay/pending" }
+        let(:cancel_url) { "http://example.com/fo/12345/worldpay/cancel" }
         let(:response_url) { "#{success_url}?orderKey=admincode1^^987654&paymentStatus=#{status}&paymentAmount=10500&paymentCurrency=GBP&mac=0ba5271e1ed1b26f9bb428ef7fb536a4&source=WP" }
         let(:path) do
           root = "/defra_ruby_mocks/worldpay/dispatcher"
           escaped_success = CGI.escape(success_url)
           escaped_failure = CGI.escape(failure_url)
           escaped_pending = CGI.escape(pending_url)
+          escaped_cancel = CGI.escape(cancel_url)
 
-          "#{root}?successURL=#{escaped_success}&failureURL=#{escaped_failure}&pendingURL=#{escaped_pending}"
+          "#{root}?successURL=#{escaped_success}&failureURL=#{escaped_failure}&pendingURL=#{escaped_pending}&cancelURL=#{escaped_cancel}"
         end
         let(:service_response) do
           double(
@@ -91,7 +93,8 @@ module DefraRubyMocks
               .with(
                 success_url: success_url,
                 failure_url: failure_url,
-                pending_url: pending_url
+                pending_url: pending_url,
+                cancel_url: cancel_url
               ) { service_response }
           end
 


### PR DESCRIPTION
This change adds the ability to 'mock' a cancelled Worldpay payment to the engine.

We generally see this when a user chooses to cancel the payment process whilst on the Worldpay site. Worldpay will redirect them back to us with a response that includes this payment status.

We cater for this in both the renewal and new registration journeys so our QA @andrewhick would also like to provide coverage via our acceptance tests.