### PR TITLE
Add mocking of errored Worldpay payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,17 +126,17 @@ This Worldpay mock replicates those 2 interactions with the following urls
 
 The engine has the ability to mock a user cancelling a payment when on the Worldpay site. To have the mock return a cancelled payment response just ensure the registration's company name includes the word `cancel` (case doesn't matter).
 
-If it does the engine will redirect back to the pending url instead of the success url provided, plus set the payment status to `CANCELLED`.
+If it does the engine will redirect back to the cancelled url instead of the success url provided, plus set the payment status to `CANCELLED`.
 
 This allows us to test how the application handles Worldpay responding with a cancelled payment response.
 
-##### Refused payments
+##### Errored payments
 
-The engine has the ability to also mock Worldpay refusing a payment. To have the mock refuse payment just ensure the registration's company name includes the word `reject` (case doesn't matter).
+The engine has the ability to Worldpay erroring during a payment. To have the mock return an errored payment response just ensure the registration's company name includes the word `error` (case doesn't matter).
 
-If it does the engine will redirect back to the failure url instead of the success url provided, plus set the payment status to `REFUSED`.
+If it does the engine will redirect back to the error url instead of the success url provided, plus set the payment status to `ERROR`.
 
-This allows us to test how the application handles both successful and unsucessful Worldpay payments.
+This allows us to test how the application handles Worldpay responding with an errored payment response.
 
 ##### Pending payments
 
@@ -145,6 +145,14 @@ The engine has the ability to also mock Worldpay marking a payment as pending. T
 If it does the engine will redirect back to the pending url instead of the success url provided, plus set the payment status to `SENT_FOR_AUTHORISATION`.
 
 This allows us to test how the application handles Worldpay responding with a payment pending response.
+
+##### Refused payments
+
+The engine has the ability to also mock Worldpay refusing a payment. To have the mock refuse payment just ensure the registration's company name includes the word `reject` (case doesn't matter).
+
+If it does the engine will redirect back to the failure url instead of the success url provided, plus set the payment status to `REFUSED`.
+
+This allows us to test how the application handles both successful and unsucessful Worldpay payments.
 
 ##### Stuck payments
 

--- a/app/controllers/defra_ruby_mocks/worldpay_controller.rb
+++ b/app/controllers/defra_ruby_mocks/worldpay_controller.rb
@@ -19,7 +19,8 @@ module DefraRubyMocks
         success_url: params[:successURL],
         failure_url: params[:failureURL],
         pending_url: params[:pendingURL],
-        cancel_url: params[:cancelURL]
+        cancel_url: params[:cancelURL],
+        error_url: params[:errorURL]
       )
 
       if @response.status == :STUCK

--- a/app/services/defra_ruby_mocks/worldpay_response_service.rb
+++ b/app/services/defra_ruby_mocks/worldpay_response_service.rb
@@ -3,12 +3,13 @@
 module DefraRubyMocks
   class WorldpayResponseService < BaseService
 
-    def run(success_url:, failure_url:, pending_url:, cancel_url:)
+    def run(success_url:, failure_url:, pending_url:, cancel_url:, error_url:)
       urls = {
         success: success_url,
         failure: failure_url,
         pending: pending_url,
-        cancel: cancel_url
+        cancel: cancel_url,
+        error: error_url
       }
 
       parse_reference(urls[:success])
@@ -68,6 +69,7 @@ module DefraRubyMocks
       return :STUCK if @resource.company_name.include?("stuck")
       return :SENT_FOR_AUTHORISATION if @resource.company_name.include?("pending")
       return :CANCELLED if @resource.company_name.include?("cancel")
+      return :ERROR if @resource.company_name.include?("error")
 
       :AUTHORISED
     end
@@ -76,6 +78,7 @@ module DefraRubyMocks
       return urls[:failure] if %i[REFUSED STUCK].include?(payment_status)
       return urls[:pending] if payment_status == :SENT_FOR_AUTHORISATION
       return urls[:cancel] if payment_status == :CANCELLED
+      return urls[:error] if payment_status == :ERROR
 
       urls[:success]
     end

--- a/spec/requests/worldpay_spec.rb
+++ b/spec/requests/worldpay_spec.rb
@@ -63,6 +63,7 @@ module DefraRubyMocks
         let(:failure_url) { "http://example.com/fo/12345/worldpay/failure" }
         let(:pending_url) { "http://example.com/fo/12345/worldpay/pending" }
         let(:cancel_url) { "http://example.com/fo/12345/worldpay/cancel" }
+        let(:error_url) { "http://example.com/fo/12345/worldpay/error" }
         let(:response_url) { "#{success_url}?orderKey=admincode1^^987654&paymentStatus=#{status}&paymentAmount=10500&paymentCurrency=GBP&mac=0ba5271e1ed1b26f9bb428ef7fb536a4&source=WP" }
         let(:path) do
           root = "/defra_ruby_mocks/worldpay/dispatcher"
@@ -70,8 +71,9 @@ module DefraRubyMocks
           escaped_failure = CGI.escape(failure_url)
           escaped_pending = CGI.escape(pending_url)
           escaped_cancel = CGI.escape(cancel_url)
+          escaped_error = CGI.escape(error_url)
 
-          "#{root}?successURL=#{escaped_success}&failureURL=#{escaped_failure}&pendingURL=#{escaped_pending}&cancelURL=#{escaped_cancel}"
+          "#{root}?successURL=#{escaped_success}&failureURL=#{escaped_failure}&pendingURL=#{escaped_pending}&cancelURL=#{escaped_cancel}&errorURL=#{escaped_error}"
         end
         let(:service_response) do
           double(
@@ -94,7 +96,8 @@ module DefraRubyMocks
                 success_url: success_url,
                 failure_url: failure_url,
                 pending_url: pending_url,
-                cancel_url: cancel_url
+                cancel_url: cancel_url,
+                error_url: error_url
               ) { service_response }
           end
 

--- a/spec/services/worldpay_response_service_spec.rb
+++ b/spec/services/worldpay_response_service_spec.rb
@@ -48,7 +48,8 @@ module DefraRubyMocks
         success_url: success_url,
         failure_url: failure_url,
         pending_url: pending_url,
-        cancel_url: cancel_url
+        cancel_url: cancel_url,
+        error_url: error_url
       }
     end
 
@@ -58,6 +59,7 @@ module DefraRubyMocks
         let(:failure_url) { "http://example.com/fo/#{reference}/worldpay/failure" }
         let(:pending_url) { "http://example.com/fo/#{reference}/worldpay/pending" }
         let(:cancel_url) { "http://example.com/fo/#{reference}/worldpay/cancel" }
+        let(:error_url) { "http://example.com/fo/#{reference}/worldpay/error" }
 
         context "and is valid" do
           let(:relation) { double(:relation, first: registration) }
@@ -142,6 +144,21 @@ module DefraRubyMocks
               expect(described_class.run(args).url).to eq(expected_response_url)
             end
           end
+
+          context "and is for an errored payment" do
+            let(:payment_status) { :ERROR }
+            let(:company_name) { "Error the thing" }
+
+            it "can generate a valid mac" do
+              expect(described_class.run(args).mac).to eq(mac)
+            end
+
+            it "returns a url in the expected format" do
+              expected_response_url = "#{error_url}?#{query_string}"
+
+              expect(described_class.run(args).url).to eq(expected_response_url)
+            end
+          end
         end
       end
 
@@ -150,6 +167,7 @@ module DefraRubyMocks
         let(:failure_url) { "http://example.com/your-registration/#{reference}/worldpay/failure/54321/NEWREG?locale=en" }
         let(:pending_url) { "http://example.com/your-registration/#{reference}/worldpay/pending/54321/NEWREG?locale=en" }
         let(:cancel_url) { "http://example.com/your-registration/#{reference}/worldpay/cancel/54321/NEWREG?locale=en" }
+        let(:error_url) { "http://example.com/your-registration/#{reference}/worldpay/error/54321/NEWREG?locale=en" }
 
         context "and is valid" do
           let(:relation) { double(:relation, first: registration) }
@@ -229,6 +247,21 @@ module DefraRubyMocks
 
             it "returns a url in the expected format" do
               expected_response_url = "#{cancel_url}&#{query_string}"
+
+              expect(described_class.run(args).url).to eq(expected_response_url)
+            end
+          end
+
+          context "and is for an errored payment" do
+            let(:payment_status) { :ERROR }
+            let(:company_name) { "Error the thing" }
+
+            it "can generate a valid mac" do
+              expect(described_class.run(args).mac).to eq(mac)
+            end
+
+            it "returns a url in the expected format" do
+              expected_response_url = "#{error_url}&#{query_string}"
 
               expect(described_class.run(args).url).to eq(expected_response_url)
             end


### PR DESCRIPTION
This change adds the ability to 'mock' an errored Worldpay payment to the engine.

Our logs seem to suggest we don't ever actually see this! But as its part of the Worldpay API we do have logic within the Waste Carriers service to handle this.

Because we cater for this in both the renewal and new registration journeys our QA @andrewhick would also like to provide coverage via our acceptance tests.