### PR TITLE
Log errors in worldpay controller

### DIFF
--- a/app/controllers/defra_ruby_mocks/worldpay_controller.rb
+++ b/app/controllers/defra_ruby_mocks/worldpay_controller.rb
@@ -10,7 +10,8 @@ module DefraRubyMocks
 
       render_payment_response if @values[:request_type] == :payment
       render_refund_response if @values[:request_type] == :refund
-    rescue StandardError
+    rescue StandardError => e
+      Rails.logger.error("MOCKS: Worldpay payments service error: #{e.message}")
       head 500
     end
 
@@ -28,7 +29,8 @@ module DefraRubyMocks
       else
         redirect_to @response.url
       end
-    rescue StandardError
+    rescue StandardError => e
+      Rails.logger.error("MOCKs: Worldpay dispatcher error: #{e.message}")
       head 500
     end
 


### PR DESCRIPTION
Currently if an error occurs in a Worldpay controller action we just return a 500 response. I'd be nice to have some idea, even if it's just in the logs, of what the error was.

This is a small tweak to add the error to the Rails log.