### PR TITLE
Add support for govpay refunds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ gemspec
 
 group :test do
   gem "faker"
+  gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     thor (1.2.1)
+    timecop (0.9.5)
     timers (4.3.3)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -286,6 +287,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails
   simplecov (~> 0.17.1)
+  timecop
 
 BUNDLED WITH
    2.3.13

--- a/app/controllers/defra_ruby_mocks/govpay_controller.rb
+++ b/app/controllers/defra_ruby_mocks/govpay_controller.rb
@@ -27,6 +27,23 @@ module DefraRubyMocks
       head 422
     end
 
+    def create_refund
+      valid_create_refund_params
+      render json: GovpayRequestRefundService.new.run(payment_id: params[:payment_id],
+                                                      amount: params[:amount],
+                                                      refund_amount_available: params[:refund_amount_available])
+    rescue StandardError => e
+      Rails.logger.error("MOCKS: Govpay refund error: #{e.message}")
+      head 500
+    end
+
+    def refund_details
+      render json: GovpayRefundDetailsService.new.run(payment_id: params[:payment_id], refund_id: params[:refund_id])
+    rescue StandardError => e
+      Rails.logger.error("MOCKS: Govpay refund error: #{e.message}")
+      head 500
+    end
+
     def valid_create_params
       params.require(%i[amount description return_url])
     end
@@ -35,6 +52,12 @@ module DefraRubyMocks
       return true if params[:payment_id].length > 20 && params[:payment_id].match(/\A[a-zA-Z0-9]*\z/)
 
       raise ArgumentError, "Invalid Govpay payment ID #{params[:payment_id]}"
+    end
+
+    def valid_create_refund_params
+      valid_payment_id
+      raise ArgumentError, "Invalid refund amount" unless params[:amount].present?
+      raise ArgumentError, "Invalid refund amount available" unless params[:refund_amount_available].present?
     end
   end
 end

--- a/app/services/defra_ruby_mocks/govpay_refund_details_service.rb
+++ b/app/services/defra_ruby_mocks/govpay_refund_details_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module DefraRubyMocks
+  class GovpayRefundDetailsService < BaseService
+
+    def run(payment_id:, refund_id:) # rubocop:disable Lint/UnusedMethodArgument
+      {
+        "amount": 2000,
+        "created_date": "2019-09-19T16:53:03.213Z",
+        "refund_id": "j6se0f2o427g28g8yg3u3i",
+        "status": status,
+        "settlement_summary": {
+          "settled_date": "2019-09-21"
+        }
+      }
+    end
+
+    private
+
+    # "submitted" for up to GOVPAY_REFUND_SUBMITTED_SUCCESS_LAG seconds after the last refund request, then "success"
+    def status
+      timestamp = File.read("#{Dir.tmpdir}/govpay_request_refund_service_last_run_time")
+      last_refund_time = timestamp ? Time.parse(timestamp) : 1.day.ago
+      submitted_success_lag = ENV.fetch("GOVPAY_REFUND_SUBMITTED_SUCCESS_LAG", 0).to_i
+      cutoff_time = (last_refund_time + submitted_success_lag.seconds).to_time
+      return "success" if submitted_success_lag.zero?
+
+      Time.zone.now < cutoff_time ? "submitted" : "success"
+    rescue Errno::ENOENT
+      write_timestamp_file("govpay_request_refund_service_last_run_time")
+
+      "success"
+    end
+
+    def write_timestamp_file(filename)
+      filepath = "#{Dir.tmpdir}/#{filename}"
+
+      # FileUtils.touch seems unreliable in VM so need to write/read the actual time
+      File.write(filepath, Time.zone.now)
+    end
+
+  end
+end

--- a/app/services/defra_ruby_mocks/govpay_request_refund_service.rb
+++ b/app/services/defra_ruby_mocks/govpay_request_refund_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module DefraRubyMocks
+  class GovpayRequestRefundService < BaseService
+
+    def run(payment_id:, amount:, refund_amount_available:) # rubocop:disable Lint/UnusedMethodArgument
+      write_timestamp
+
+      # This currently supports only "submitted" status:
+      {
+        "amount": amount,
+        "created_date": "2019-09-19T16:53:03.213Z",
+        "refund_id": "j6se0f2o427g28g8yg3u3i",
+        "status": "submitted"
+      }
+    end
+
+    private
+
+    # let the refund details service know how long since the refund was requested
+    def write_timestamp
+      filepath = "#{Dir.tmpdir}/govpay_request_refund_service_last_run_time"
+      # FileUtils.touch seems unreliable in VM so need to write/read the actual time
+      File.write(filepath, Time.zone.now)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,4 +20,14 @@ DefraRubyMocks::Engine.routes.draw do
       to: "govpay#payment_details",
       as: "govpay_payment_details",
       constraints: ->(_request) { DefraRubyMocks.configuration.enabled? }
+
+  post "/govpay/v1/payments/:payment_id/refunds",
+       to: "govpay#create_refund",
+       as: "govpay_create_refund",
+       constraints: ->(_request) { DefraRubyMocks.configuration.enabled? }
+
+  get "/govpay/v1/payments/:payment_id/refunds/:refund_id",
+      to: "govpay#refund_details",
+      as: "govpay_refund_details",
+      constraints: ->(_request) { DefraRubyMocks.configuration.enabled? }
 end

--- a/spec/requests/govpay_spec.rb
+++ b/spec/requests/govpay_spec.rb
@@ -50,7 +50,7 @@ module DefraRubyMocks
         context "when the request is missing a mandatory parameter" do
           before { payment_request[:amount] = nil }
 
-          it "returns a HTTP 500 responseß" do
+          it "returns a HTTP 500 response" do
             post path, params: payment_request.as_json
 
             expect(response.code).to eq "500"
@@ -90,6 +90,49 @@ module DefraRubyMocks
             get path
 
             expect(response.code).to eq "422"
+          end
+        end
+      end
+
+      describe "#create_refund" do
+        let(:payment_id) { "12345678901234567890123456" }
+        let(:path) { "/defra_ruby_mocks/govpay/v1/payments/#{payment_id}/refunds" }
+        let(:refund_request) do
+          {
+            "amount": 2000,
+            "refund_amount_available": 5000
+          }
+        end
+
+        context "when the request is missing a mandatory parameter" do
+          before { refund_request[:refund_amount_available] = nil }
+
+          it "returns a HTTP 500 response" do
+            post path, params: refund_request.as_json
+
+            expect(response.code).to eq "500"
+          end
+        end
+
+        context "with a valid request" do
+          it "returns a valid success response" do
+            post path, params: refund_request.as_json
+
+            expect(response.code).to eq "200"
+          end
+        end
+      end
+
+      describe "#refund_details" do
+        let(:payment_id) { "12345678901234567890123456" }
+        let(:refund_id) { "j6se0f2o427g28g8yg3u3i" }
+        let(:path) { "/defra_ruby_mocks/govpay/v1/payments/#{payment_id}/refunds/#{refund_id}" }
+
+        context "with a valid request" do
+          it "returns a valid success response" do
+            get path
+
+            expect(response.code).to eq "200"
           end
         end
       end

--- a/spec/services/govpay_refund_details_service_spec.rb
+++ b/spec/services/govpay_refund_details_service_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module DefraRubyMocks
+
+  RSpec.describe GovpayRefundDetailsService do
+    let(:payment_id) { SecureRandom.hex(26) }
+    let(:refund_id) { SecureRandom.hex(22) }
+
+    before { Helpers::Configuration.prep_for_tests }
+
+    # Note that the service currently supports only success responses.
+    describe ".run" do
+      let(:create_request_time) { Time.zone.now }
+      let(:submitted_success_lag) { "10" }
+
+      subject { described_class.run(payment_id: payment_id, refund_id: refund_id).deep_symbolize_keys }
+
+      # the service shoud return "submitted" for up to GOVPAY_REFUND_SUBMITTED_SUCCESS_LAG seconds, "success" thereafter
+      before do
+        Timecop.freeze(create_request_time)
+        allow(ENV).to receive(:fetch).with("GOVPAY_REFUND_SUBMITTED_SUCCESS_LAG", any_args).and_return(submitted_success_lag)
+        FileUtils.rm_rf("#{Dir.tmpdir}/govpay_request_refund_service_last_run_time")
+      end
+
+      context "when no refund timestamp file exists" do
+        it { expect(subject[:status]).to eq "success" }
+      end
+
+      context "when a refund has been requested" do
+        before do
+          GovpayRequestRefundService.run(payment_id: payment_id, amount: 100, refund_amount_available: 100).deep_symbolize_keys
+        end
+
+        context "when less than 10 seconds has elapsed since the last create request" do
+          before { Timecop.freeze(create_request_time + (submitted_success_lag.to_i - 8).seconds) }
+
+          it { expect(subject[:status]).to eq "submitted" }
+        end
+
+        context "when 10 seconds has elapsed since the last create request" do
+          before { Timecop.freeze(create_request_time + (submitted_success_lag.to_i + 8).seconds) }
+
+          it { expect(subject[:status]).to eq "success" }
+        end
+
+        context "when GOVPAY_REFUND_SUBMITTED_SUCCESS_LAG is not set" do
+          let(:submitted_success_lag) { nil }
+
+          before { Timecop.freeze(create_request_time + 1.hour) }
+
+          it { expect(subject[:status]).to eq "success" }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/govpay_request_refund_service_spec.rb
+++ b/spec/services/govpay_request_refund_service_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module DefraRubyMocks
+
+  RSpec.describe GovpayRequestRefundService do
+    let(:payment_id) { SecureRandom.hex(26) }
+    let(:amount) { 2000 }
+    let(:refund_amount_available) { amount }
+
+    before { Helpers::Configuration.prep_for_tests }
+
+    # Note that the service currently supports only "submitted" responses.
+    describe ".run" do
+
+      subject { described_class.run(payment_id: payment_id, amount: amount, refund_amount_available: refund_amount_available).deep_symbolize_keys }
+
+      context "when the refund has been successfully submitted" do
+
+        it "returns a response with the expected status" do
+          expect(subject[:status]).to eq("submitted")
+        end
+
+        it "returns a response with the expected amount" do
+          expect(subject[:amount]).to eq(amount)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds mock APIs for govpay refunds, including simulation of refund approval lag.
https://eaflood.atlassian.net/browse/RUBY-2433