### PR TITLE
[RUBY-3230] Fix incorrect environment variable for S3 bucket in Defra Ruby Mocks

### DIFF
--- a/app/services/defra_ruby_mocks/govpay_refund_details_service.rb
+++ b/app/services/defra_ruby_mocks/govpay_refund_details_service.rb
@@ -40,7 +40,7 @@ module DefraRubyMocks
     end
 
     def s3_bucket_name
-      @s3_bucket_name = ENV.fetch("GOVPAY_MOCKS_BUCKET", "defra-ruby-mocks-s3bkt001")
+      @s3_bucket_name = ENV.fetch("AWS_DEFRA_RUBY_MOCKS_BUCKET", nil)
     end
 
     def timestamp_file_name

--- a/app/services/defra_ruby_mocks/govpay_request_refund_service.rb
+++ b/app/services/defra_ruby_mocks/govpay_request_refund_service.rb
@@ -24,7 +24,7 @@ module DefraRubyMocks
     end
 
     def s3_bucket_name
-      @s3_bucket_name = ENV.fetch("GOVPAY_MOCKS_BUCKET", "defra-ruby-mocks-s3bkt001")
+      @s3_bucket_name = ENV.fetch("AWS_DEFRA_RUBY_MOCKS_BUCKET", nil)
     end
 
     def timestamp_file_name


### PR DESCRIPTION
- Updated `s3_bucket_name` method in `govpay_refund_details_service.rb` and `govpay_request_refund_service.rb` to fetch `AWS_DEFRA_RUBY_MOCKS_BUCKET` instead of `GOVPAY_MOCKS_BUCKET`.
