### PR TITLE
feature/RUBY-3754_govpay_webhooks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     defra_ruby_mocks (5.0.0)
       defra_ruby_aws (~> 0.5)
       rails (~> 7.0)
+      rest-client (~> 2.0)
       sprockets (~> 4.0)
       sprockets-rails (~> 3.0)
 
@@ -144,6 +145,7 @@ GEM
       rubocop-rspec
     diff-lcs (1.5.1)
     docile (1.4.0)
+    domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.12.0)
     faker (3.5.1)
@@ -167,6 +169,9 @@ GEM
       rake (>= 10.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    http-accept (1.7.0)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -177,6 +182,7 @@ GEM
     jmespath (1.6.2)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    logger (1.7.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -187,6 +193,10 @@ GEM
       net-smtp
     marcel (1.0.4)
     method_source (1.0.0)
+    mime-types (3.6.2)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2025.0422)
     mini_mime (1.1.5)
     minitest (5.23.1)
     multi_json (1.15.0)
@@ -200,6 +210,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.3)
     nokogiri (1.16.5-x86_64-darwin)
       racc (~> 1.4)
@@ -277,6 +288,11 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.7)
       io-console (~> 0.5)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.3.9)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)

--- a/app/controllers/defra_ruby_mocks/govpay_test_helpers_controller.rb
+++ b/app/controllers/defra_ruby_mocks/govpay_test_helpers_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module DefraRubyMocks
+  class GovpayTestHelpersController < ::DefraRubyMocks::ApplicationController
+
+    skip_before_action :verify_authenticity_token
+
+    # These are helpers for the automated acceptance tests.
+
+    # The mock will use the value passed in to populate the status field on all future payments.
+    def set_test_payment_response_status
+      Rails.logger.info "MOCKS: Setting payment response status to #{params[:status]}"
+
+      AwsBucketService.write(s3_bucket_name, "test_payment_response_status", params[:status])
+
+      head 200
+    end
+
+    # The mock will use the value passed in to populate the status field on all future refunds.
+    def set_test_refund_response_status
+      Rails.logger.info "MOCKS: Setting refund response status to #{params[:status]}"
+
+      AwsBucketService.write(s3_bucket_name, "test_refund_response_status", params[:status])
+
+      head 200
+    end
+
+    # This schedules a job to send a mock payment webhook.
+    def send_payment_webhook
+      Rails.logger.warn "MOCKS: Sending payment webhook for #{params[:govpay_id]}, status #{params[:payment_status]}"
+      %w[govpay_id payment_status callback_url signing_secret].each do |p|
+        raise StandardError, "Missing parameter: '#{p}'" unless params[p].present?
+      end
+
+      SendPaymentWebhookJob.perform_later(
+        params[:govpay_id],
+        params[:payment_status],
+        params[:callback_url],
+        params[:signing_secret]
+      )
+
+      head 200
+    end
+
+    # This schedules a job to send a mock refund webhook.
+    def send_refund_webhook
+      Rails.logger.warn "MOCKS: Sending refund webhook for #{params[:govpay_id]}, status #{params[:refund_status]}"
+      %w[govpay_id refund_status callback_url signing_secret].each do |p|
+        raise StandardError, "Missing parameter: '#{p}'" unless params[p].present?
+      end
+
+      SendRefundWebhookJob.perform_later(
+        params[:govpay_id],
+        params[:refund_status],
+        params[:callback_url],
+        params[:signing_secret]
+      )
+
+      head 200
+    end
+
+    private
+
+    def s3_bucket_name
+      @s3_bucket_name = ENV.fetch("AWS_DEFRA_RUBY_MOCKS_BUCKET", nil)
+    end
+  end
+end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+  queue_as :default
+end

--- a/app/jobs/base_send_webhook_job.rb
+++ b/app/jobs/base_send_webhook_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class BaseSendWebhookJob < ApplicationJob
+  def perform(govpay_id:, status:, callback_url:, signing_secret:)
+    body = webhook_body(govpay_id:, status:)
+    Rails.logger.warn "MOCKS: sending #{webhook_type} webhook for #{govpay_id}, status \"#{status}\" to #{callback_url}"
+    RestClient::Request.execute(
+      method: :get,
+      url: callback_url,
+      body: body,
+      headers: { "Pay-Signature": webhook_signature(body, signing_secret) }
+    )
+  rescue StandardError => e
+    Rails.logger.error "MOCKS: error sending #{webhook_type} webhook to #{callback_url}: #{e}\n#{e.backtrace}"
+  end
+
+  private
+
+  def webhook_type
+    raise NotImplementedError
+  end
+
+  def webhook_body(govpay_id:, status:)
+    raise NotImplementedError
+  end
+
+  def webhook_signature(webhook_body, signing_secret)
+    OpenSSL::HMAC.hexdigest("sha256", signing_secret.encode("utf-8"), webhook_body.to_json.encode("utf-8"))
+  end
+
+end

--- a/app/jobs/send_payment_webhook_job.rb
+++ b/app/jobs/send_payment_webhook_job.rb
@@ -1,31 +1,19 @@
 # frozen_string_literal: true
 
-class SendPaymentWebhookJob < ApplicationJob
-  def perform(govpay_id:, payment_status:, callback_url:, signing_secret:)
-    webhook_body = payment_webhook_body(govpay_id:, payment_status:)
-    RestClient::Request.execute(
-      method: :get,
-      url: callback_url,
-      body: webhook_body,
-      headers: { "Pay-Signature": webhook_signature(webhook_body, signing_secret) }
-    )
-  rescue StandardError => e
-    Rails.logger.error "MOCKS: error sending payment webhook to #{callback_url}: #{e}\n#{e.backtrace}"
-  end
+class SendPaymentWebhookJob < BaseSendWebhookJob
 
   private
 
-  def payment_webhook_body(govpay_id:, payment_status:)
+  def webhook_type
+    "payment"
+  end
+
+  def webhook_body(govpay_id:, status:)
     webhook_body ||= JSON.parse(File.read("lib/fixtures/files/govpay/webhook_payment_update_body.json"))
 
     webhook_body["resource"]["payment_id"] = govpay_id
-    webhook_body["resource"]["state"]["status"] = payment_status
+    webhook_body["resource"]["state"]["status"] = status
 
     webhook_body
   end
-
-  def webhook_signature(webhook_body, signing_secret)
-    OpenSSL::HMAC.hexdigest("sha256", signing_secret.encode("utf-8"), webhook_body.to_json.encode("utf-8"))
-  end
-
 end

--- a/app/jobs/send_payment_webhook_job.rb
+++ b/app/jobs/send_payment_webhook_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class SendPaymentWebhookJob < ApplicationJob
+  def perform(govpay_id:, payment_status:, callback_url:, signing_secret:)
+    webhook_body = payment_webhook_body(govpay_id:, payment_status:)
+    RestClient::Request.execute(
+      method: :get,
+      url: callback_url,
+      body: webhook_body,
+      headers: { "Pay-Signature": webhook_signature(webhook_body, signing_secret) }
+    )
+  rescue StandardError => e
+    Rails.logger.error "MOCKS: error sending payment webhook to #{callback_url}: #{e}\n#{e.backtrace}"
+  end
+
+  private
+
+  def payment_webhook_body(govpay_id:, payment_status:)
+    webhook_body ||= JSON.parse(File.read("lib/fixtures/files/govpay/webhook_payment_update_body.json"))
+
+    webhook_body["resource"]["payment_id"] = govpay_id
+    webhook_body["resource"]["state"]["status"] = payment_status
+
+    webhook_body
+  end
+
+  def webhook_signature(webhook_body, signing_secret)
+    OpenSSL::HMAC.hexdigest("sha256", signing_secret.encode("utf-8"), webhook_body.to_json.encode("utf-8"))
+  end
+
+end

--- a/app/jobs/send_refund_webhook_job.rb
+++ b/app/jobs/send_refund_webhook_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class SendRefundWebhookJob < ApplicationJob
+  def perform(govpay_id:, refund_status:, callback_url:, signing_secret:)
+    webhook_body = refund_webhook_body(govpay_id:, refund_status:)
+    Rails.logger.warn "+++ mocks sending refund webhook for #{govpay_id}, status \"#{refund_status}\" to #{callback_url}"
+    RestClient::Request.execute(
+      method: :get,
+      url: callback_url,
+      body: webhook_body,
+      headers: { "Pay-Signature": webhook_signature(webhook_body, signing_secret) }
+    )
+  rescue StandardError => e
+    Rails.logger.error "MOCKS: error sending refund webhook to #{callback_url}: #{e}\n#{e.backtrace}"
+  end
+
+  private
+
+  def refund_webhook_body(govpay_id:, refund_status:)
+    webhook_body ||= JSON.parse(File.read("lib/fixtures/files/govpay/webhook_refund_update_body.json"))
+
+    webhook_body["payment_id"] = govpay_id
+    webhook_body["status"] = refund_status
+
+    webhook_body
+  end
+
+  def webhook_signature(webhook_body, signing_secret)
+    OpenSSL::HMAC.hexdigest("sha256", signing_secret.encode("utf-8"), webhook_body.to_json.encode("utf-8"))
+  end
+
+end

--- a/app/jobs/send_refund_webhook_job.rb
+++ b/app/jobs/send_refund_webhook_job.rb
@@ -1,32 +1,19 @@
 # frozen_string_literal: true
 
-class SendRefundWebhookJob < ApplicationJob
-  def perform(govpay_id:, refund_status:, callback_url:, signing_secret:)
-    webhook_body = refund_webhook_body(govpay_id:, refund_status:)
-    Rails.logger.warn "+++ mocks sending refund webhook for #{govpay_id}, status \"#{refund_status}\" to #{callback_url}"
-    RestClient::Request.execute(
-      method: :get,
-      url: callback_url,
-      body: webhook_body,
-      headers: { "Pay-Signature": webhook_signature(webhook_body, signing_secret) }
-    )
-  rescue StandardError => e
-    Rails.logger.error "MOCKS: error sending refund webhook to #{callback_url}: #{e}\n#{e.backtrace}"
-  end
+class SendRefundWebhookJob < BaseSendWebhookJob
 
   private
 
-  def refund_webhook_body(govpay_id:, refund_status:)
+  def webhook_type
+    "refund"
+  end
+
+  def webhook_body(govpay_id:, status:)
     webhook_body ||= JSON.parse(File.read("lib/fixtures/files/govpay/webhook_refund_update_body.json"))
 
     webhook_body["payment_id"] = govpay_id
-    webhook_body["status"] = refund_status
+    webhook_body["status"] = status
 
     webhook_body
   end
-
-  def webhook_signature(webhook_body, signing_secret)
-    OpenSSL::HMAC.hexdigest("sha256", signing_secret.encode("utf-8"), webhook_body.to_json.encode("utf-8"))
-  end
-
 end

--- a/app/services/defra_ruby_mocks/govpay_create_payment_service.rb
+++ b/app/services/defra_ruby_mocks/govpay_create_payment_service.rb
@@ -21,6 +21,19 @@ module DefraRubyMocks
 
     private
 
+    def s3_bucket_name
+      @s3_bucket_name = ENV.fetch("AWS_DEFRA_RUBY_MOCKS_BUCKET", nil)
+    end
+
+    # Check if a non-default status value has been requested
+    def test_payment_response_status
+      AwsBucketService.read(s3_bucket_name, "test_payment_response_status") || "created"
+    rescue StandardError => e
+      # This is expected behaviour when the payment status default override file is not present.
+      Rails.logger.warn ":::::: mocks failed to read test_payment_response_status: #{e}"
+      "created"
+    end
+
     def base_url
       File.join(DefraRubyMocks.configuration.govpay_domain, "/payments")
     end
@@ -34,7 +47,7 @@ module DefraRubyMocks
       {
         created_date: "2020-03-03T16:17:19.554Z",
         state: {
-          status: "created",
+          status: test_payment_response_status,
           finished: false
         },
         _links: {

--- a/app/services/defra_ruby_mocks/govpay_get_payment_service.rb
+++ b/app/services/defra_ruby_mocks/govpay_get_payment_service.rb
@@ -19,6 +19,15 @@ module DefraRubyMocks
 
     private
 
+    # Check if a non-default status value has been requested
+    def test_payment_response_status
+      AwsBucketService.read(s3_bucket_name, "test_payment_response_status") || "success"
+    rescue StandardError => e
+      # This is expected behaviour when the payment status default override file is not present.
+      Rails.logger.warn ":::::: mocks failed to read test_payment_response_status: #{e}"
+      "success"
+    end
+
     # rubocop:disable Metrics/MethodLength
     def response_success
       {
@@ -32,7 +41,7 @@ module DefraRubyMocks
         },
         email: "sherlock.holmes@example.com",
         state: {
-          status: "success",
+          status: test_payment_response_status,
           finished: true
         },
         payment_id: "cnnffa1e6s3u9a6n24u2cp527d",

--- a/app/services/defra_ruby_mocks/govpay_request_refund_service.rb
+++ b/app/services/defra_ruby_mocks/govpay_request_refund_service.rb
@@ -6,16 +6,24 @@ module DefraRubyMocks
     def run(payment_id:, amount:, refund_amount_available:) # rubocop:disable Lint/UnusedMethodArgument
       write_timestamp
 
-      # This currently supports only "submitted" status:
       {
         amount: amount,
         created_date: "2019-09-19T16:53:03.213Z",
         refund_id: SecureRandom.hex(22),
-        status: "submitted"
+        status: test_refund_response_status
       }
     end
 
     private
+
+    # Check if a non-default status value has been requested
+    def test_refund_response_status
+      AwsBucketService.read(s3_bucket_name, "test_refund_response_status") || "submitted"
+    rescue StandardError => e
+      # This is expected behaviour when the refund status default override file is not present.
+      Rails.logger.warn ":::::: mocks failed to read test_refund_response_status: #{e}"
+      "submitted"
+    end
 
     # let the refund details service know how long since the refund was requested
     def write_timestamp

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,4 +35,25 @@ DefraRubyMocks::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
       to: "govpay#refund_details",
       as: "govpay_refund_details",
       constraints: ->(_request) { DefraRubyMocks.configuration.enabled? }
+
+  # test helpers, not mocks:
+  get "/govpay/v1/payments/set_test_payment_response_status/:status",
+      to: "govpay_test_helpers#set_test_payment_response_status",
+      as: "govpay_set_test_payment_response_status",
+      constraints: ->(_request) { DefraRubyMocks.configuration.enabled? }
+
+  get "/govpay/v1/payments/set_test_refund_response_status/:status",
+      to: "govpay_test_helpers#set_test_refund_response_status",
+      as: "govpay_set_test_refund_response_status",
+      constraints: ->(_request) { DefraRubyMocks.configuration.enabled? }
+
+  post "/govpay/v1/payments/:govpay_id/send_payment_webhook",
+       to: "govpay_test_helpers#send_payment_webhook",
+       as: "send_payment_webhook",
+       constraints: ->(_request) { DefraRubyMocks.configuration.enabled? }
+
+  post "/govpay/v1/payments/:govpay_id/send_refund_webhook",
+       to: "govpay_test_helpers#send_refund_webhook",
+       as: "send_refund_webhook",
+       constraints: ->(_request) { DefraRubyMocks.configuration.enabled? }
 end

--- a/defra_ruby_mocks.gemspec
+++ b/defra_ruby_mocks.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.description = "A Rails engine which can be used to mock external services when loaded into an application"
   s.license     = "The Open Government Licence (OGL) Version 3"
 
+  s.metadata["rubygems_mfa_required"] = "true"
+
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
   s.required_ruby_version = ">= 3.2.2"
@@ -27,5 +29,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "defra_ruby_aws", "~> 0.5"
 
-  s.metadata["rubygems_mfa_required"] = "true"
+  # Use rest-client for external requests
+  s.add_dependency "rest-client", "~> 2.0"
 end

--- a/lib/fixtures/files/govpay/webhook_payment_update_body.json
+++ b/lib/fixtures/files/govpay/webhook_payment_update_body.json
@@ -1,0 +1,48 @@
+{
+    "webhook_message_id": "123abc",
+    "api_version": 1,
+    "created_date": "2019-07-11T10:36:26.988Z",
+    "resource_id": "hu20sqlact5260q2nanm0q8u93",
+    "resource_type": "payment",
+    "event_type": "card_payment_captured",
+    "resource": {
+      "amount": 5000,
+      "description": "Pay your council tax",
+      "reference": "12345",
+      "language": "en",
+      "email": "sherlock.holmes@example.com",
+      "state": {
+        "status": "success",
+        "finished": false
+      },
+      "payment_id": "hu20sqlact5260q2nanm0q8u93",
+      "payment_provider": "stripe",
+      "created_date": "2021-10-19T10:05:45.454Z",
+      "refund_summary": {
+        "status": "pending",
+        "amount_available": 5000,
+        "amount_submitted": 0
+      },
+      "settlement_summary": {},
+      "card_details": {
+        "last_digits_card_number": "1234",
+        "first_digits_card_number": "123456",
+        "cardholder_name": "Sherlock Holmes",
+        "expiry_date": "04/24",
+        "billing_address": {
+          "line1": "221 Baker Street",
+          "line2": "Flat b",
+          "postcode": "NW1 6XE",
+          "city": "London",
+          "country": "GB"
+        },
+        "card_brand": "Visa",
+        "card_type": "debit"
+      },
+      "delayed_capture": false,
+      "moto": false,
+      "provider_id": "10987654321",
+      "return_url": "https://your.service.gov.uk/completed"
+    }
+  }
+  

--- a/lib/fixtures/files/govpay/webhook_refund_update_body.json
+++ b/lib/fixtures/files/govpay/webhook_refund_update_body.json
@@ -1,0 +1,8 @@
+{
+    "refund_id": "345",
+    "created_date": "2022-01-26T16:52:41.178Z",
+    "amount": 2000,
+    "status": "success",
+    "settlement_summary": {},
+    "payment_id": "789"
+}

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -12,6 +12,9 @@ Bundler.require(*Rails.groups)
 
 module Dummy
   class Application < Rails::Application
+
+    config.load_defaults 7.0
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/spec/jobs/send_payment_webhook_job_spec.rb
+++ b/spec/jobs/send_payment_webhook_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "restclient"
+
+RSpec.describe SendPaymentWebhookJob do
+
+  describe "#perform" do
+    subject(:run_job) { described_class.new.perform(govpay_id:, payment_status:, callback_url:, signing_secret:) }
+
+    let(:govpay_id) { SecureRandom.hex }
+    let(:signing_secret) { SecureRandom.hex(16) }
+    let(:payment_status) { "success" }
+    let(:callback_url) { Faker::Internet.url }
+
+    let(:http_client) { instance_double(RestClient::Request) }
+
+    before do
+      allow(RestClient::Request).to receive(:new).and_return(http_client)
+      allow(http_client).to receive(:execute)
+    end
+
+    it { expect { run_job }.not_to raise_error }
+
+    it "sends the webhook" do
+      run_job
+
+      expect(http_client).to have_received(:execute) # .with(method: :get)
+    end
+  end
+end

--- a/spec/jobs/send_payment_webhook_job_spec.rb
+++ b/spec/jobs/send_payment_webhook_job_spec.rb
@@ -6,11 +6,11 @@ require "restclient"
 RSpec.describe SendPaymentWebhookJob do
 
   describe "#perform" do
-    subject(:run_job) { described_class.new.perform(govpay_id:, payment_status:, callback_url:, signing_secret:) }
+    subject(:run_job) { described_class.new.perform(govpay_id:, status:, callback_url:, signing_secret:) }
 
     let(:govpay_id) { SecureRandom.hex }
     let(:signing_secret) { SecureRandom.hex(16) }
-    let(:payment_status) { "success" }
+    let(:status) { "success" }
     let(:callback_url) { Faker::Internet.url }
 
     let(:http_client) { instance_double(RestClient::Request) }
@@ -25,7 +25,7 @@ RSpec.describe SendPaymentWebhookJob do
     it "sends the webhook" do
       run_job
 
-      expect(http_client).to have_received(:execute) # .with(method: :get)
+      expect(http_client).to have_received(:execute)
     end
   end
 end

--- a/spec/jobs/send_refund_webhook_job_spec.rb
+++ b/spec/jobs/send_refund_webhook_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "restclient"
+
+RSpec.describe SendRefundWebhookJob do
+
+  describe "#perform" do
+    subject(:run_job) { described_class.new.perform(govpay_id:, refund_status:, callback_url:, signing_secret:) }
+
+    let(:govpay_id) { SecureRandom.hex }
+    let(:signing_secret) { SecureRandom.hex(16) }
+    let(:refund_status) { "success" }
+    let(:callback_url) { Faker::Internet.url }
+
+    let(:http_client) { instance_double(RestClient::Request) }
+
+    before do
+      allow(RestClient::Request).to receive(:new).and_return(http_client)
+      allow(http_client).to receive(:execute)
+    end
+
+    it { expect { run_job }.not_to raise_error }
+
+    it "sends the webhook" do
+      run_job
+
+      expect(http_client).to have_received(:execute) # .with(method: :get)
+    end
+  end
+end

--- a/spec/jobs/send_refund_webhook_job_spec.rb
+++ b/spec/jobs/send_refund_webhook_job_spec.rb
@@ -6,11 +6,11 @@ require "restclient"
 RSpec.describe SendRefundWebhookJob do
 
   describe "#perform" do
-    subject(:run_job) { described_class.new.perform(govpay_id:, refund_status:, callback_url:, signing_secret:) }
+    subject(:run_job) { described_class.new.perform(govpay_id:, status:, callback_url:, signing_secret:) }
 
     let(:govpay_id) { SecureRandom.hex }
     let(:signing_secret) { SecureRandom.hex(16) }
-    let(:refund_status) { "success" }
+    let(:status) { "success" }
     let(:callback_url) { Faker::Internet.url }
 
     let(:http_client) { instance_double(RestClient::Request) }
@@ -25,7 +25,7 @@ RSpec.describe SendRefundWebhookJob do
     it "sends the webhook" do
       run_job
 
-      expect(http_client).to have_received(:execute) # .with(method: :get)
+      expect(http_client).to have_received(:execute)
     end
   end
 end

--- a/spec/requests/govpay_test_helpers_spec.rb
+++ b/spec/requests/govpay_test_helpers_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module DefraRubyMocks
+  RSpec.describe "GovpayTestHelpers" do
+    let(:base_mocks_url) { File.join(DefraRubyMocks.configuration.govpay_domain, "/govpay/v1/payments") }
+
+    context "when mocks are enabled" do
+      let(:aws_bucket_service) { instance_double(AwsBucketService) }
+
+      before do
+        Helpers::Configuration.prep_for_tests
+
+        DefraRubyMocks.configure do |config|
+          config.govpay_domain = "http://localhost:3000/defra_ruby_mocks"
+        end
+
+        allow(AwsBucketService).to receive(:new).and_return(aws_bucket_service)
+        allow(aws_bucket_service).to receive(:read)
+        allow(aws_bucket_service).to receive(:write)
+        allow(aws_bucket_service).to receive(:remove)
+      end
+
+      # This is just a test helper, so just confirm that it attempts to write to S3
+      describe "#set_test_payment_response_status" do
+        before { get "/defra_ruby_mocks/govpay/v1/payments/set_test_payment_response_status/submitted" }
+
+        it { expect(aws_bucket_service).to have_received(:write) }
+      end
+
+      # This is just a test helper, so just confirm that it attempts to write to S3
+      describe "#set_test_refund_response_status" do
+        before { get "/defra_ruby_mocks/govpay/v1/payments/set_test_refund_response_status/submitted" }
+
+        it { expect(aws_bucket_service).to have_received(:write) }
+      end
+
+      describe "#send_payment_webhook" do
+        let(:request_mock_webhook_path) { "/defra_ruby_mocks/govpay/v1/payments/#{SecureRandom.hex(22)}/send_payment_webhook" }
+        let(:params) do
+          {
+            payment_status: "success",
+            callback_url: Faker::Internet.url,
+            signing_secret: SecureRandom.hex(16)
+          }
+        end
+
+        let(:response_json) { JSON.parse(response.body) }
+
+        it "returns HTTP 200" do
+          post request_mock_webhook_path, params: params
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "enqueues a job" do
+          expect { post request_mock_webhook_path, params: params }.to have_enqueued_job(SendPaymentWebhookJob)
+        end
+      end
+
+      describe "#send_refund_webhook" do
+        let(:request_mock_webhook_path) { "/defra_ruby_mocks/govpay/v1/payments/#{SecureRandom.hex(22)}/send_refund_webhook" }
+        let(:params) do
+          {
+            refund_status: "success",
+            callback_url: Faker::Internet.url,
+            signing_secret: SecureRandom.hex(16)
+          }
+        end
+
+        let(:response_json) { JSON.parse(response.body) }
+
+        it "returns HTTP 200" do
+          post request_mock_webhook_path, params: params
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "enqueues a job" do
+          expect { post request_mock_webhook_path, params: params }.to have_enqueued_job(SendRefundWebhookJob)
+        end
+      end
+    end
+
+    context "when mocks are disabled" do
+      before { DefraRubyMocks.configuration.enable = false }
+
+      let(:payment_id) { Faker::Alphanumeric.alphanumeric(number: 26) }
+
+      context "with GET #set_test_payment_response_status" do
+        let(:path) { "/defra_ruby_mocks/govpay/v1/payments/set_test_payment_response_status/submitted" }
+
+        it "cannot load the page" do
+          expect { post path }.to raise_error(ActionController::RoutingError)
+        end
+      end
+
+      context "with GET #set_test_refund_response_status" do
+        let(:path) { "/defra_ruby_mocks/govpay/v1/payments/set_test_refund_response_status/submitted" }
+
+        it "cannot load the page" do
+          expect { get path }.to raise_error(ActionController::RoutingError)
+        end
+      end
+
+      describe "with #send_payment_webhook" do
+        let(:path) { "/defra_ruby_mocks/govpay/v1/payments/#{SecureRandom.hex(22)}/send_payment_webhook" }
+
+        it "cannot load the page" do
+          expect { post path }.to raise_error(ActionController::RoutingError)
+        end
+      end
+
+      describe "with #send_refund_webhook" do
+        let(:path) { "/defra_ruby_mocks/govpay/v1/payments/#{SecureRandom.hex(22)}/send_refund_webhook" }
+
+        it "cannot load the page" do
+          expect { post path }.to raise_error(ActionController::RoutingError)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/defra_ruby_mocks/aws_bucket_service_spec.rb
+++ b/spec/services/defra_ruby_mocks/aws_bucket_service_spec.rb
@@ -7,13 +7,17 @@ module DefraRubyMocks
   RSpec.describe AwsBucketService do
     let(:s3_bucket_name) { "s3_bucket" }
     let(:s3_bucket) { instance_double(DefraRuby::Aws::Bucket) }
+    let(:s3_client) { instance_double(Aws::S3::Client) }
 
-    before { allow(DefraRuby::Aws).to receive(:get_bucket).with(s3_bucket_name).and_return(s3_bucket) }
+    before do
+      allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+      allow(DefraRuby::Aws).to receive(:get_bucket).with(s3_bucket_name).and_return(s3_bucket)
+    end
 
     describe ".write" do
-      let(:s3_load_result) { instance_double(DefraRuby::Aws::Response) }
-
       subject(:write_bucket) { described_class.write(s3_bucket_name, "a_file_name", "some content") }
+
+      let(:s3_load_result) { instance_double(DefraRuby::Aws::Response) }
 
       before { allow(s3_bucket).to receive(:load).and_return(s3_load_result) }
 
@@ -35,11 +39,8 @@ module DefraRubyMocks
     describe ".read" do
       let(:expected_content) { Faker::Lorem.sentence }
       let(:aws_response) { instance_double(Aws::S3::Types::GetObjectOutput, body: StringIO.new(expected_content)) }
-      let(:s3_client) { instance_double(Aws::S3::Client) }
 
       subject(:read_bucket) { described_class.read(s3_bucket_name, "a_file_name") }
-
-      before { allow(Aws::S3::Client).to receive(:new).and_return(s3_client) }
 
       context "when bucket#read fails" do
         before { allow(s3_client).to receive(:get_object).and_raise(Aws::S3::Errors::NoSuchBucket) }
@@ -51,6 +52,25 @@ module DefraRubyMocks
         before { allow(s3_client).to receive(:get_object).and_return(aws_response) }
 
         it { expect(read_bucket).to eq(expected_content) }
+      end
+    end
+
+    describe ".remove" do
+      let(:target_file) { "file_to_remove" }
+      let(:s3_load_result) { instance_double(DefraRuby::Aws::Response) }
+
+      before do
+        allow(s3_bucket).to receive(:load).and_return(s3_load_result)
+        allow(s3_load_result).to receive(:successful?).and_return(true)
+        allow(s3_bucket).to receive(:delete)
+
+        described_class.write(s3_bucket_name, target_file, "foo")
+      end
+
+      it "deletes the file" do
+        described_class.remove(s3_bucket_name, target_file)
+
+        expect(s3_bucket).to have_received(:delete)
       end
     end
   end

--- a/spec/services/defra_ruby_mocks/govpay_refund_details_service_spec.rb
+++ b/spec/services/defra_ruby_mocks/govpay_refund_details_service_spec.rb
@@ -38,7 +38,9 @@ module DefraRubyMocks
           Timecop.freeze(last_request_time) do
             GovpayRequestRefundService.run(payment_id: payment_id, amount: 100, refund_amount_available: 100).deep_symbolize_keys
           end
-          allow(aws_bucket_service).to receive(:read).and_return(last_request_time.to_s)
+          allow(aws_bucket_service).to receive(:read)
+            .with(ENV.fetch("AWS_DEFRA_RUBY_MOCKS_BUCKET", nil), "govpay_request_refund_service_last_run_time")
+            .and_return(last_request_time.to_s)
         end
 
         context "when less than 10 seconds has elapsed since the last create request" do
@@ -50,10 +52,7 @@ module DefraRubyMocks
         context "when 10 seconds has elapsed since the last create request" do
           let(:last_request_time) { Time.zone.now - 11.seconds }
 
-          it do
-            puts "spec time now #{Time.zone.now}"
-            expect(run_service[:status]).to eq "success"
-          end
+          it { expect(run_service[:status]).to eq "success" }
         end
 
         context "when GOVPAY_REFUND_SUBMITTED_SUCCESS_LAG is not set" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,3 +84,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
+
+def response_json
+  JSON.parse(response.body)
+end


### PR DESCRIPTION
This change adds helper routes to support automated testing:
- set payment status to be used for all future payment creation requests (unless and until changed)
- set refund status to be used for all future refund creation requests (unless and until changed)
- request a mock payment webhook
- request a mock refund webhook
https://eaflood.atlassian.net/browse/RUBY-3754