### PR TITLE
Fix/ruby 3754 refund id in webhook

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       rubocop-factory_bot
       rubocop-rake
       rubocop-rspec
-    diff-lcs (1.6.1)
+    diff-lcs (1.6.2)
     docile (1.4.0)
     domain_name (0.6.20240107)
     dotenv (3.1.8)
@@ -184,7 +184,7 @@ GEM
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.24.0)
+    loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -240,7 +240,7 @@ GEM
     pry-byebug (3.11.0)
       byebug (~> 12.0)
       pry (>= 0.13, < 0.16)
-    psych (5.2.4)
+    psych (5.2.6)
       date
       stringio
     public_suffix (5.0.1)

--- a/app/jobs/send_refund_webhook_job.rb
+++ b/app/jobs/send_refund_webhook_job.rb
@@ -11,7 +11,7 @@ class SendRefundWebhookJob < BaseSendWebhookJob
   def webhook_body(govpay_id:, status:)
     webhook_body ||= JSON.parse(File.read("lib/fixtures/files/govpay/webhook_refund_update_body.json"))
 
-    webhook_body["payment_id"] = govpay_id
+    webhook_body["refund_id"] = govpay_id
     webhook_body["status"] = status
 
     webhook_body

--- a/spec/jobs/send_payment_webhook_job_spec.rb
+++ b/spec/jobs/send_payment_webhook_job_spec.rb
@@ -13,12 +13,9 @@ RSpec.describe SendPaymentWebhookJob do
     let(:status) { "success" }
     let(:callback_url) { Faker::Internet.url }
 
-    let(:http_client) { instance_double(RestClient::Request) }
+    let(:http_client) { class_double(RestClient::Request).as_stubbed_const }
 
-    before do
-      allow(RestClient::Request).to receive(:new).and_return(http_client)
-      allow(http_client).to receive(:execute)
-    end
+    before { allow(http_client).to receive(:execute).with(instance_of(Hash)) }
 
     it { expect { run_job }.not_to raise_error }
 
@@ -26,6 +23,7 @@ RSpec.describe SendPaymentWebhookJob do
       run_job
 
       expect(http_client).to have_received(:execute)
+        .with(hash_including(payload: /"payment_id":"#{govpay_id}"/))
     end
   end
 end

--- a/spec/jobs/send_refund_webhook_job_spec.rb
+++ b/spec/jobs/send_refund_webhook_job_spec.rb
@@ -13,12 +13,9 @@ RSpec.describe SendRefundWebhookJob do
     let(:status) { "success" }
     let(:callback_url) { Faker::Internet.url }
 
-    let(:http_client) { instance_double(RestClient::Request) }
+    let(:http_client) { class_double(RestClient::Request).as_stubbed_const }
 
-    before do
-      allow(RestClient::Request).to receive(:new).and_return(http_client)
-      allow(http_client).to receive(:execute)
-    end
+    before { allow(http_client).to receive(:execute).with(instance_of(Hash)) }
 
     it { expect { run_job }.not_to raise_error }
 
@@ -26,6 +23,7 @@ RSpec.describe SendRefundWebhookJob do
       run_job
 
       expect(http_client).to have_received(:execute)
+        .with(hash_including(payload: /"refund_id":"#{govpay_id}"/))
     end
   end
 end


### PR DESCRIPTION
Add specs for govpay_ids in webhook bodies and fix assignment of govpay_id in `SendRefundWebhookJob`
https://eaflood.atlassian.net/browse/RUBY-3754